### PR TITLE
Add lazygit-style p/P aliases for pull/push

### DIFF
--- a/.config/zsh/aliases.zsh
+++ b/.config/zsh/aliases.zsh
@@ -3,3 +3,7 @@ alias wget="wget --hsts-file=$XDG_DATA_HOME/wget-hsts"
 alias cl='clear'
 
 
+
+# lazygit-style git keybinds: p=pull, P=push (case-sensitive, unlike git aliases)
+alias p='git pull'
+alias P='git push'


### PR DESCRIPTION
Adds shell aliases `p`=`git pull` and `P`=`git push` in `.config/zsh/aliases.zsh`, mirroring the lazygit keybinds.

Note: these are shell aliases rather than git aliases, because git alias names are case-insensitive (`p` and `P` collide). Shell aliases are case-sensitive, so this actually distinguishes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)