### PR TITLE
feat: add clipcdn uploader for self-hosted MinIO CDN

### DIFF
--- a/.config/clipcdn/config.example
+++ b/.config/clipcdn/config.example
@@ -1,0 +1,23 @@
+# clipcdn config — copy to ~/.config/clipcdn/config and fill in.
+# This file is sourced by the `clipcdn` script; keep it shell-safe.
+#
+#   cp ~/.config/clipcdn/config.example ~/.config/clipcdn/config
+#   chmod 600 ~/.config/clipcdn/config   # it holds a secret key
+#
+# NOTE: real credentials must NOT be committed. Only this .example is tracked.
+
+# Public S3/CDN endpoint (the MinIO cdn_hostname).
+CDN_ENDPOINT="https://cdn.rutgerpronk.com"
+
+# MinIO credentials (root user/password, or a dedicated access key pair).
+CDN_ACCESS_KEY="admin"
+CDN_SECRET_KEY="change-me"
+
+# Public bucket to upload into (matches the MinIO module's bucket_name).
+CDN_BUCKET="cdn"
+
+# Where `clipcdn --clips` looks for clips to sync.
+CLIPS_DIR="$HOME/Videos/Clips"
+
+# Local mc alias name (cosmetic).
+MC_ALIAS="homecdn"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 *.log
 .claude/settings.local.json
+
+# clipcdn holds a MinIO secret key — only the .example is tracked
+.config/clipcdn/config

--- a/.local/bin/clipcdn
+++ b/.local/bin/clipcdn
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# clipcdn — upload clips (and build artifacts) to my self-hosted MinIO CDN and
+# print the shareable URL. Backed by the MinIO client (`mc`).
+#
+# Config lives at ~/.config/clipcdn/config (see clipcdn.example in dev-env).
+# Env vars override the config file.
+#
+# Usage:
+#   clipcdn <file> [remote/path]     Upload a single file
+#   clipcdn --clips [dir]            Sync ~/Videos/Clips -> <bucket>/clips
+#   clipcdn --artifact <file> [name] Upload to <bucket>/artifacts (for APKs etc.)
+#   clipcdn --list [prefix]          List what's on the CDN
+#   clipcdn --setup                  (Re)configure the mc alias from config
+#
+set -euo pipefail
+
+CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/clipcdn/config"
+
+# --- Load config -------------------------------------------------------------
+# shellcheck disable=SC1090
+[ -f "$CONFIG_FILE" ] && source "$CONFIG_FILE"
+
+CDN_ENDPOINT="${CDN_ENDPOINT:-}"          # e.g. https://cdn.rutgerpronk.com
+CDN_ACCESS_KEY="${CDN_ACCESS_KEY:-}"      # MinIO access key / root user
+CDN_SECRET_KEY="${CDN_SECRET_KEY:-}"      # MinIO secret key / root password
+CDN_BUCKET="${CDN_BUCKET:-cdn}"           # public bucket name
+CLIPS_DIR="${CLIPS_DIR:-$HOME/Videos/Clips}"
+MC_ALIAS="${MC_ALIAS:-homecdn}"
+
+die() { echo "clipcdn: $*" >&2; exit 1; }
+
+need_mc() {
+  command -v mc >/dev/null 2>&1 || die "'mc' (MinIO client) not found. Install it (yay -S minio-client / mcli)."
+}
+
+check_config() {
+  [ -n "$CDN_ENDPOINT" ]   || die "CDN_ENDPOINT not set. Configure $CONFIG_FILE"
+  [ -n "$CDN_ACCESS_KEY" ] || die "CDN_ACCESS_KEY not set. Configure $CONFIG_FILE"
+  [ -n "$CDN_SECRET_KEY" ] || die "CDN_SECRET_KEY not set. Configure $CONFIG_FILE"
+}
+
+setup_alias() {
+  need_mc; check_config
+  mc alias set "$MC_ALIAS" "$CDN_ENDPOINT" "$CDN_ACCESS_KEY" "$CDN_SECRET_KEY" >/dev/null
+}
+
+public_url() {
+  # $1 = key within the bucket (no leading slash)
+  echo "${CDN_ENDPOINT%/}/${CDN_BUCKET}/$1"
+}
+
+# Upload one local file to <bucket>/<key>. Prints the public URL.
+upload_one() {
+  local src="$1" key="$2"
+  [ -f "$src" ] || die "not a file: $src"
+  mc cp "$src" "$MC_ALIAS/$CDN_BUCKET/$key" >/dev/null
+  public_url "$key"
+}
+
+cmd_file() {
+  local src="$1"
+  local key="${2:-$(basename "$src")}"
+  setup_alias
+  local url; url="$(upload_one "$src" "$key")"
+  echo "$url"
+}
+
+cmd_artifact() {
+  local src="$1"
+  local name="${2:-$(basename "$src")}"
+  setup_alias
+  local url; url="$(upload_one "$src" "artifacts/$name")"
+  echo "$url"
+}
+
+cmd_clips() {
+  local dir="${1:-$CLIPS_DIR}"
+  [ -d "$dir" ] || die "clips dir not found: $dir"
+  setup_alias
+  echo "Syncing $dir -> $MC_ALIAS/$CDN_BUCKET/clips ..." >&2
+  # mirror = upload new/changed files, keep existing remote files.
+  mc mirror --overwrite "$dir" "$MC_ALIAS/$CDN_BUCKET/clips"
+  echo "Done. Base URL: $(public_url clips)/" >&2
+}
+
+cmd_list() {
+  local prefix="${1:-}"
+  setup_alias
+  mc ls --recursive "$MC_ALIAS/$CDN_BUCKET/$prefix"
+}
+
+usage() {
+  sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# --- Dispatch ----------------------------------------------------------------
+[ $# -ge 1 ] || usage 1
+
+case "$1" in
+  -h|--help)      usage 0 ;;
+  --setup)        setup_alias; echo "mc alias '$MC_ALIAS' configured for $CDN_ENDPOINT" ;;
+  --clips)        shift; cmd_clips "${1:-}" ;;
+  --artifact)     shift; [ $# -ge 1 ] || die "usage: clipcdn --artifact <file> [name]"; cmd_artifact "$@" ;;
+  --list)         shift; cmd_list "${1:-}" ;;
+  -*)             die "unknown option: $1 (see --help)" ;;
+  *)              cmd_file "$@" ;;
+esac

--- a/README.md
+++ b/README.md
@@ -121,6 +121,37 @@ applications/
 2. Install wanted games
 
 
+## clipcdn — upload clips & artifacts to my CDN
+
+`clipcdn` (in `.local/bin`) uploads files to my self-hosted MinIO CDN
+(`cdn.rutgerpronk.com`, deployed from `kubernetes-infrastructure/5-minio`) and
+prints a shareable URL. Handy for sharing clips with mates and for grabbing
+build artifacts (e.g. the soundboard APK) straight onto a phone.
+
+It uses the MinIO client (`mc`), installed via the optional `clipcdn` package
+group (`minio-client`).
+
+### Setup
+
+```bash
+cp ~/.config/clipcdn/config.example ~/.config/clipcdn/config
+chmod 600 ~/.config/clipcdn/config      # holds a secret key
+$EDITOR ~/.config/clipcdn/config         # fill in endpoint + credentials
+clipcdn --setup                          # register the mc alias
+```
+
+The real `config` is gitignored; only `config.example` is tracked.
+
+### Usage
+
+```bash
+clipcdn clip.mp4                  # -> https://cdn.rutgerpronk.com/cdn/clip.mp4
+clipcdn clip.mp4 clips/funny.mp4  # custom remote path
+clipcdn --clips                   # sync ~/Videos/Clips -> <bucket>/clips
+clipcdn --artifact app-debug.apk  # upload to <bucket>/artifacts (for testing)
+clipcdn --list                    # list what's on the CDN
+```
+
 ## Adding Support for New Distributions
 
 To add support for a new distribution:

--- a/applications/packages/optional/arch/clipcdn.lst
+++ b/applications/packages/optional/arch/clipcdn.lst
@@ -1,0 +1,2 @@
+# MinIO client — used by the `clipcdn` uploader for my self-hosted CDN
+minio-client


### PR DESCRIPTION
Adds a `clipcdn` CLI (in `.local/bin`, so it lands on `PATH` via stow) that uploads files to my self-hosted MinIO CDN and prints a shareable URL. Backed by the MinIO client (`mc`).

Pairs with the `5-minio` module in `kubernetes-infrastructure`.

## Commands
```bash
clipcdn <file>            # upload one file, print public URL
clipcdn <file> path/x.mp4 # custom remote path
clipcdn --clips [dir]     # mirror ~/Videos/Clips -> <bucket>/clips
clipcdn --artifact <f>    # upload build artifacts (e.g. the soundboard APK)
clipcdn --list [prefix]   # list CDN contents
clipcdn --setup           # register the mc alias from config
```

## Config
Lives at `~/.config/clipcdn/config`. Only `config.example` is tracked — the real file holds a secret key and is **gitignored**.

```bash
cp ~/.config/clipcdn/config.example ~/.config/clipcdn/config
chmod 600 ~/.config/clipcdn/config
clipcdn --setup
```

## Also
- Optional `clipcdn` package group installs `minio-client`.
- README section documenting setup + usage.

Syntax-checked with `bash -n`.